### PR TITLE
added enable_servo function to 3_microros_rviz and 4_microros_gazebo

### DIFF
--- a/firmware/3_microros_rviz/main/main.c
+++ b/firmware/3_microros_rviz/main/main.c
@@ -122,7 +122,8 @@ void micro_ros_task(void * arg)
   	memset(test_array,'z',ARRAY_LEN);
 	rcl_allocator_t allocator = rcl_get_default_allocator();
 	rclc_support_t support;
-
+	enable_servo();
+	
 	// Create init_options.
 	rcl_init_options_t init_options = rcl_get_zero_initialized_init_options();
 	RCCHECK(rcl_init_options_init(&init_options, allocator));

--- a/firmware/4_microros_gazebo/main/main.c
+++ b/firmware/4_microros_gazebo/main/main.c
@@ -117,7 +117,7 @@ void micro_ros_task(void * arg)
   	memset(test_array,'z',ARRAY_LEN);
 	rcl_allocator_t allocator = rcl_get_default_allocator();
 	rclc_support_t support;
-
+	enable_servo();
 	// Create init_options.
 	rcl_init_options_t init_options = rcl_get_zero_initialized_init_options();
 	RCCHECK(rcl_init_options_init(&init_options, allocator));


### PR DESCRIPTION
Added enable_servo() function in micro_ros task function to intialize the servos when the task is created. 
Absence of this function will cause some errors while using the code to control servos, that is now fixed with this commit 