### PR TITLE
Rviz to Rviz2 porting with updated main README.md

### DIFF
--- a/3_simulation_rviz/CMakeLists.txt
+++ b/3_simulation_rviz/CMakeLists.txt
@@ -30,10 +30,17 @@ find_package(robot_state_publisher REQUIRED)
 #   DESTINATION lib/${PROJECT_NAME}
 # )
 
+install (PROGRAMS 
+   scripts/rviz.py
+DESTINATION lib/${PROJECT_NAME}
+)
+
 install(
   DIRECTORY config launch meshes rviz scripts urdf
   DESTINATION share/${PROJECT_NAME}
 )
+
+
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/3_simulation_rviz/README.md
+++ b/3_simulation_rviz/README.md
@@ -40,7 +40,7 @@ ros2 launch simulation_rviz mario_rviz.launch
 ```
 * To give input angles from command line
 ```
-ros2 run 3_simulation_rviz/scripts/rviz.py
+ros2run 3_simulation_rviz/scripts/rviz.py
 ```
 
 *you can use your this command to view the topics actively published . This will show if the values are published to the toppic we want to.

--- a/3_simulation_rviz/README.md
+++ b/3_simulation_rviz/README.md
@@ -40,7 +40,7 @@ ros2 launch simulation_rviz mario_rviz.launch
 ```
 * To give input angles from command line
 ```
-ros2 run simulation_rviz/scripts/rviz.py
+ros2 run simulation_rviz scripts/rviz.py
 ```
 
 *you can use your this command to view the topics actively published . This will show if the values are published to the toppic we want to.

--- a/3_simulation_rviz/README.md
+++ b/3_simulation_rviz/README.md
@@ -40,7 +40,7 @@ ros2 launch simulation_rviz mario_rviz.launch
 ```
 * To give input angles from command line
 ```
-ros2run 3_simulation_rviz/scripts/rviz.py
+ros2 run simulation_rviz/scripts/rviz.py
 ```
 
 *you can use your this command to view the topics actively published . This will show if the values are published to the toppic we want to.

--- a/3_simulation_rviz/README.md
+++ b/3_simulation_rviz/README.md
@@ -1,12 +1,21 @@
 ## Steps to run the demo in RViz 
-Repo with new URDF of manipulator to visualize in RViz and using command line as well as gui to give input to RViz  
+Introduction to RViz 2:
+
+RViz 2 is a powerful 3D visualization tool provided by the Robot Operating System (ROS) 2 ecosystem. It serves as an essential component for roboticists, engineers, and researchers to visualize and interact with robot models, sensor data, and other important information in a simulated or real-world environment. RViz 2 offers a user-friendly interface with a wide range of features tailored to support the development, debugging, and testing of robotic systems.Here , along we can visualize the URDF of manipulator on Rviz using command line as well as GUI to give input.
 
 If you have not installed the joint_state_publishers and ros_control for ros-noetic, follow the commands given [here](https://github.com/SRA-VJTI/MARIO/tree/master/2_simulation_dh)
 
+* Remember : Whenever you are using ros commands in another terminal , make sure you  source the ros commands:
+```
+source install/setup.bash
+```
+  
+
 *  Run the launch file
 ```
-  roslaunch simulation_rviz display.launch 
+  ros2 launch simulation_rviz display.launch 
 ```
+
 
 <p align="center">
   <img src="../assets/launch1.png" width="500"/>
@@ -16,8 +25,10 @@ If you have not installed the joint_state_publishers and ros_control for ros-noe
    *  If you come across this error  
 Could not find the GUI, install the 'joint_state_publisher_gui' package  
    *  Install  using  
-sudo apt install ros-<your_version_of_ros>-joint-state-publisher-gui 
-----------------------------------------------------------------------  
+sudo apt install ros-<your_version_of_ros>-joint-state-publisher-gui
+   * Install all the packages required in the same way if needed.
+ 
+ ----------------------------------------------------------------------  
   
 *  Once you are done with the visualisation with gui , Ctrl+ c to stop this .  
   
@@ -25,12 +36,22 @@ sudo apt install ros-<your_version_of_ros>-joint-state-publisher-gui
 *  For command line input    
 
 ```
-roslaunch simulation_rviz mario_rviz.launch    
+ros2 launch simulation_rviz mario_rviz.launch    
 ```
-*  Now ,On a different terminal, source ROS again and go to the simulation folder and write the following command
+* To give input angles from command line
+```
+ros2 run 3_simulation_rviz/scripts/rviz.py
+```
 
+*you can use your this command to view the topics actively published . This will show if the values are published to the toppic we want to.
 ```
-rosrun simulation_rviz pub_rviz.py  
+ros2 topic list
+```
+*To observe the published data in another terminal 
+```
+ros2 topic echo
 ```
 Then initially set all values to zero , to get the default position of the manipulator .  
 After this you can now check for different values.
+
+As you give the input in the terminal , you can observe how the manipulator moved according to your input values of angles between links.

--- a/3_simulation_rviz/launch/display.launch.py
+++ b/3_simulation_rviz/launch/display.launch.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+# with GUI 
 import os
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
@@ -82,14 +83,9 @@ def generate_launch_description():
             executable='static_transform_publisher',
             arguments=["0.0091023", "0.0182709", "-0.090512", "0", "0", "0", "link_3", "claw_left"]
         )
-    # load_joint_position_controller = ExecuteProcess(
-    #     cmd=['ros2', 'control', 'load_controller', '--set-state', 'active', 'position_controllers'],
-    # output='screen'
-    # )
-    # create and return launch description object
     print("==> Using Sim time\n")
     return LaunchDescription([  
-        # load_joint_position_controller,
+
         tf2_link1,tf2_link2,tf2_link3,tf2_claw_left,tf2_claw_right,
         robot_state_publisher_node,
         rviz_launch,

--- a/3_simulation_rviz/launch/rviz.launch.py
+++ b/3_simulation_rviz/launch/rviz.launch.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+#without GUI
 import os
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
@@ -14,7 +15,6 @@ import random
 def generate_launch_description():
     ####### DATA INPUT ##########
     urdf_file = 'manipulator.urdf'
-    #xacro_file = "box_bot.xacro"robot_description
     package_description = "simulation_rviz"
     ####### DATA INPUT END ##########
     config = os.path.join( get_package_share_directory('simulation_rviz'),
@@ -23,14 +23,7 @@ def generate_launch_description():
     )
     robot_desc_path = os.path.join(get_package_share_directory(package_description), "urdf", urdf_file)
     print("Fetching URDF ==>")
-
-    # joint_state_publisher = Node(
-    #         package="joint_state_publisher",
-    #         executable="joint_state_publisher"
-    #         )
-
-
-
+    
     # Robot State Publisher
     robot_state_publisher_node = Node(
         package='robot_state_publisher',
@@ -40,7 +33,7 @@ def generate_launch_description():
         parameters=[{'use_sim_time': True, '-r': 10, 'robot_description': ParameterValue(Command(['xacro ',robot_desc_path]), value_type=str)}],
         output="screen"
     )
-
+ 
     rviz_launch = Node(
             package='rviz2',
             namespace='',
@@ -49,49 +42,45 @@ def generate_launch_description():
             parameters=[{'use_sim_time' : True}],
             arguments=['-d' + os.path.join(get_package_share_directory(package_description), 'rviz', 'manipulator.rviz')]
         )
+     # This node is to publish static funtion values of base link to link 1
     tf2_link1 = Node(
             package='tf2_ros',
             namespace='',
             executable='static_transform_publisher',
             arguments=["-0.0030196", "0.046937", "0.0635", "0", "0", "0", "base_link", "link_1"]
         )
+     # This node is to publish static funtion values of link 1 to link 2
     tf2_link2 = Node(
             package='tf2_ros',
             namespace='',
             executable='static_transform_publisher',
             arguments=["0.00031511", "-0.0095653", "0.034407", "0", "0", "0", "link_1", "link_2"]
         )
-
+     # This node is to publish static funtion values of link 2 to link 3
     tf2_link3 = Node(
             package='tf2_ros',
             namespace='',
             executable='static_transform_publisher',
             arguments=["0.071531", "0.011279", "-0.0041348", "0", "0", "0", "link_2", "link_3"]
         )
-    
+     # This node is to publish static funtion values of link 3 to link claw_right
     tf2_claw_right = Node(
             package='tf2_ros',
             namespace='',
             executable='static_transform_publisher',
             arguments=["0.020925", "-0.013767", "-0.090331", "0", "0", "0", "link_3", "claw_right"]
         )
-    
+     # This node is to publish static funtion values of claw_right to claw_left
     tf2_claw_left = Node(
             package='tf2_ros',
             namespace='',
             executable='static_transform_publisher',
             arguments=["0.0091023", "0.0182709", "-0.090512", "0", "0", "0", "link_3", "claw_left"]
         )
-    # load_joint_position_controller = ExecuteProcess(
-    #     cmd=['ros2', 'control', 'load_controller', '--set-state', 'active', 'position_controllers'],
-    # output='screen'
-    # )
-    # create and return launch description object
+  
     print("==> Using Sim time\n")
     return LaunchDescription([  
-        # load_joint_position_controller,
         tf2_link1,tf2_link2,tf2_link3,tf2_claw_left,tf2_claw_right,
         robot_state_publisher_node,
         rviz_launch,
-        # joint_state_publisher,
     ])

--- a/3_simulation_rviz/scripts/rviz.py
+++ b/3_simulation_rviz/scripts/rviz.py
@@ -7,7 +7,6 @@ from tf2_ros.static_transform_broadcaster import StaticTransformBroadcaster
 from std_msgs.msg import Header
 from rclpy import qos
 import math
-from std_msgs.msg import String
 import geometry_msgs.msg
 import sys
 
@@ -47,11 +46,9 @@ if __name__ == '__main__':
     rclpy.init(args=sys.argv)
     global node 
     node = rclpy.create_node('joint_state_pub')
-    node.get_logger().info(' Enter your Angles')
-    pub = node.create_publisher(String, 'chatter', qos_profile=qos.qos_profile_parameters)
+    node.get_logger().info(' Enter your Angles ')
     msg = String()
     msg.data = 'hello_str\n'
     node.create_timer(0.1, talker)
-    pub.publish(msg)
     rclpy.spin(node)
     rclpy.shutdown()

--- a/3_simulation_rviz/scripts/rviz.py
+++ b/3_simulation_rviz/scripts/rviz.py
@@ -1,14 +1,17 @@
-#!/usr/bin/env python3
-
+# #!/usr/bin/env python3
 import rclpy
 from rclpy.node import Node
 from sensor_msgs.msg import JointState
+from geometry_msgs.msg import TransformStamped
+from tf2_ros.static_transform_broadcaster import StaticTransformBroadcaster
 from std_msgs.msg import Header
 from rclpy import qos
 import math
+from std_msgs.msg import String
+import geometry_msgs.msg
 import sys
 
-
+# This function publishes the input angles of the user.
 def talker():
     global node
     pub = node.create_publisher(JointState,'joint_states', qos_profile=qos.qos_profile_parameter_events)
@@ -21,7 +24,8 @@ def talker():
     theta_elbow = float(input("{:22s}".format("Enter theta_elbow: ")))
     theta_claw1 = float(input("{:22s}".format("Enter theta_claw 1: ")))
     theta_claw2 = float(input("{:22s}".format("Enter theta_claw 2: ")))
-    
+
+    # theta must be in the range of 0 to 180 degree.
     if 0 <= theta_base <= 180.0 and 0 <= theta_shoulder <= 180.0 and 0 <= theta_elbow <= 180.0 and 0.0 <= theta_claw1 <= 180.0 and 0.0 <= theta_claw2 <= 180.0 : 
         theta_base = (theta_base)*math.pi/180
         theta_shoulder = (theta_shoulder)*math.pi/180
@@ -42,7 +46,12 @@ if __name__ == '__main__':
 
     rclpy.init(args=sys.argv)
     global node 
-    node = Node('joint_state_pub')
+    node = rclpy.create_node('joint_state_pub')
+    node.get_logger().info(' Enter your Angles')
+    pub = node.create_publisher(String, 'chatter', qos_profile=qos.qos_profile_parameters)
+    msg = String()
+    msg.data = 'hello_str\n'
     node.create_timer(0.1, talker)
+    pub.publish(msg)
     rclpy.spin(node)
     rclpy.shutdown()

--- a/3_simulation_rviz/scripts/rviz.py
+++ b/3_simulation_rviz/scripts/rviz.py
@@ -47,8 +47,6 @@ if __name__ == '__main__':
     global node 
     node = rclpy.create_node('joint_state_pub')
     node.get_logger().info(' Enter your Angles ')
-    msg = String()
-    msg.data = 'hello_str\n'
     node.create_timer(0.1, talker)
     rclpy.spin(node)
     rclpy.shutdown()

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Society of Robotics and Automation
+Copyright (c) 2024 SRA
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 SRA
+Copyright (c) 2024 Society of Robotics and Automation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,66 +1,61 @@
-# MARIO WORKSHOP 2.2
-*MARIO* abbreviation for *Manipulator on ROS Based Input Output* is a bot with 3 Degree of Freedom. It consists of two SG90 micro servo and one MG995 metal gear servo motor. The servo motors are placed on base, elbow and shoulder enabling it with 3 Degrees of Freedom.
+## Steps to run the demo in RViz 
+Introduction to RViz 2:
 
-## Sneek Peek 
+RViz 2 is a powerful 3D visualization tool provided by the Robot Operating System (ROS) 2 ecosystem. It serves as an essential component for roboticists, engineers, and researchers to visualize and interact with robot models, sensor data, and other important information in a simulated or real-world environment. RViz 2 offers a user-friendly interface with a wide range of features tailored to support the development, debugging, and testing of robotic systems.Here , along we can visualize the URDF of manipulator on Rviz using command line as well as GUI to give input.
+
+If you have not installed the joint_state_publishers and ros_control for ros-noetic, follow the commands given [here](https://github.com/SRA-VJTI/MARIO/tree/master/2_simulation_dh)
+
+* Remember : Whenever you are using ros commands in another terminal , make sure you  source the ros commands:
+```
+source install /setup.bash
+```
+  
+
+*  Run the launch file
+```
+  roslaunch simulation_rviz display.launch 
+```
 
 
-<p align="center"><img src="assets/bot2.png"></p>
-
-### Working of the Mario Bot
-
-<p align="center"><img src="assets/Gif2_AdobeExpress.gif" width="500" height="500"></p>
-
-### Mario bot simulated using Gazebo 
-
-<p align="center"><img src="assets/simulation.png"></p>
+<p align="center">
+  <img src="../assets/launch1.png" width="500"/>
+</p>
 
 
+   *  If you come across this error  
+Could not find the GUI, install the 'joint_state_publisher_gui' package  
+   *  Install  using  
+sudo apt install ros-<your_version_of_ros>-joint-state-publisher-gui
+   * Install all the packages required in the same way if needed.
+ 
+ ----------------------------------------------------------------------  
+  
+*  Once you are done with the visualisation with gui , Ctrl+ c to stop this .  
+  
+  
+*  For command line input    
 
-## File Structure 
-    ├── 1_chatter_listener            # talker and listener script to understand the nodes and communications in ROS
-    ├── 2_simulation_dh               # simulation of DH paramteres
-    ├── 3_simulation_rviz             # simulation of MARIO bot on rviz
-    ├── 4_simulation_gazebo           # simulation of MARIO bot on gazebo
-    ├── assets                        # contains necessary gifs, images 
-    ├── firmware                      # contains ESP-IDF examples for controlling servo motors and rosserial
-    │   ├── 1_servo_set_zero          # example in ESP-IDF to set angles of all servo motor zero
-    │   ├── 2_servo_sweep             # example in ESP-IDF to set variable angles in servo motor
-    │   ├── 3_rosserial_rviz          # example in ESP-IDF to interface with rviz environment as well as ESP32
-    │   ├── 4_rosserial_gazebo        # example in ESP-IDF to interface with gazebo environment as well as ESP32
-    │   ├── 5_servo_test_webserver    # example in ESP-IDF to set angles of servo over the webserver interface
-    │   └── components                # contains all the dependencies required for the above examples
-    │       ├── rosserial_esp32       # rosserial library to setup interface between ros environment and ESP32
-    │       └── sra-board-component   # library to interface with SRA board
-    ├── LICENSE
-    └── README.md 
+```
+roslaunch simulation_rviz mario_rviz.launch    
+```
+* To give input angles from command line
+```
+python3 3_simulation_rviz/scripts/rviz.py
+```
 
-## Kinematics
-* Mario workshop aims to provide the basic knowledge about the DH parameters, forward kinematics , inverse kinematics.
-  * DH Parameters :- Denavit–Hartenberg parameters (also called DH parameters) are the four parameters associated with a particular convention for attaching reference frames to the links of a spatial kinematic chain, or robot manipulator
-  * Forward Kinematics :- Forward kinematics refers to the use of the kinematic equations of a robot to compute the position of the end-effector from specified values for the joint parameters. The kinematics equations of the robot are used in robotics, computer games, and animation.
-  * Inverse Kinematics :- inverse kinematics is the mathematical process of calculating the variable joint parameters needed to place the end of a kinematic chain, such as a robot manipulator or animation character's skeleton, in a given position and orientation relative to the start of the chain.
-## ROS 
-ROS is an open-source, meta-operating system for your robot. It provides the services you would expect from an operating system, 
-including hardware abstraction, low-level device control, implementation of commonly-used functionality, message-passing between processes,
-and package management.
+*you can use your this command to view the topics actively published . This will show if the values are published to the toppic we want to.
+```
+ros2 topic lsit
+```
+*To observe the published data in another terminal 
+```
+ros2 topic echo
+```
+*  Now ,On a different terminal, source ROS again and go to the simulation folder and write the following command
+```
+rosrun simulation_rviz pub_rviz.py  
+```
+Then initially set all values to zero , to get the default position of the manipulator .  
+After this you can now check for different values.
 
-## Publisher and Subscriber
-Publish/Subscribe is a messaging pattern that aims to decouple the sending (Publisher) and receiving (Subscriber) party. A real world example could be a sport mobile app that shows you up-to-date information of a particular football game you're interested in. In this case you are the subscriber, as you express interest in this specific game. On the other side sits the publisher, which is an online reporter that feeds a system with the actual match data.
-This system, which is often referred as the message broker brings the two parties together by sending the new data to all interested subscribers.
-
-While ROS works on the same system, this system is also used in various other libraries like MQTT.
-
-## ESPIDF
-ESP-IDF is the development framework for Espressif SoCs.The [SRA Board](https://github.com/SRA-VJTI/sra-board-hardware-design) uses ESP32 as microcontroller, hence ESPIDF is required
-to code the ESP32. Examples included inside firmware directory has been written in ESPIDF version 4.2 .
-
-## ROSSERIAL
-ROS Serial is a point-to-point version of ROS communications over serial, primarily for integrating low-cost microcontrollers (Arduino) into ROS. 
-ROS serial consists of a general p2p protocol, libraries for use with Arduino, and nodes for the PC/Tablet side (currently in both Python and Java).
-
-## Installation of ROS
-
-ROS Noetic is now used by MARIO, and there are two ways to install it.
-Running `install_codes_jammy.sh` for 22.04 installs ROS Noetic via [Robostack](https://robostack.github.io/), whereas running `install_codes_focal.sh` for 20.04 installs ROS Noetic via the official ROS repository.
-
-`install_codes_jammy.sh` requires itself to be run twice, and run using the command `bash -i install_codes_jammy.sh`. The first time it is run, it will install the Robostack repository, and the second time it is run, it will install ROS Noetic and all the required packages.
+As you give the input in the terminal , you can observe how the manipulator moved according to your input values of angles between links.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ### Working of the Mario Bot
 
-<p align="center"><img src="assets/Gif2_AdobeExpress.gif" width="500" height="500"></p>
+<p align="center"><img src="assets/simulation_mario_v2.3.gif" width="500" height="500"></p>
 
 ### Mario bot simulated using Gazebo 
 
@@ -39,10 +39,8 @@
   * DH Parameters :- Denavit–Hartenberg parameters (also called DH parameters) are the four parameters associated with a particular convention for attaching reference frames to the links of a spatial kinematic chain, or robot manipulator
   * Forward Kinematics :- Forward kinematics refers to the use of the kinematic equations of a robot to compute the position of the end-effector from specified values for the joint parameters. The kinematics equations of the robot are used in robotics, computer games, and animation.
   * Inverse Kinematics :- inverse kinematics is the mathematical process of calculating the variable joint parameters needed to place the end of a kinematic chain, such as a robot manipulator or animation character's skeleton, in a given position and orientation relative to the start of the chain.
-## ROS 
-ROS is an open-source, meta-operating system for your robot. It provides the services you would expect from an operating system, 
-including hardware abstraction, low-level device control, implementation of commonly-used functionality, message-passing between processes,
-and package management.
+## ROS-2 
+ROS2 is the ultimate toolkit for robotics enthusiasts and professionals alike. Seamlessly integrating hardware and software, ROS2 streamlines development workflows, accelerates prototyping, and enables rapid iteration. With its modular architecture and extensive library of reusable components, ROS2 simplifies the creation of complex robotics projects, from autonomous drones to collaborative robot arms. 
 
 ## Publisher and Subscriber
 Publish/Subscribe is a messaging pattern that aims to decouple the sending (Publisher) and receiving (Subscriber) party. A real world example could be a sport mobile app that shows you up-to-date information of a particular football game you're interested in. In this case you are the subscriber, as you express interest in this specific game. On the other side sits the publisher, which is an online reporter that feeds a system with the actual match data.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MARIO WORKSHOP 2.2
+# MARIO WORKSHOP 2.3
 *MARIO* abbreviation for *Manipulator on ROS Based Input Output* is a bot with 3 Degree of Freedom. It consists of two SG90 micro servo and one MG995 metal gear servo motor. The servo motors are placed on base, elbow and shoulder enabling it with 3 Degrees of Freedom.
 
 ## Sneek Peek 
@@ -17,20 +17,20 @@
 
 
 ## File Structure 
-    ├── 1_chatter_listener            # talker and listener script to understand the nodes and communications in ROS
-    ├── 2_simulation_dh               # simulation of DH paramteres
-    ├── 3_simulation_rviz             # simulation of MARIO bot on rviz
-    ├── 4_simulation_gazebo           # simulation of MARIO bot on gazebo
-    ├── assets                        # contains necessary gifs, images 
-    ├── firmware                      # contains ESP-IDF examples for controlling servo motors and rosserial
-    │   ├── 1_servo_set_zero          # example in ESP-IDF to set angles of all servo motor zero
-    │   ├── 2_servo_sweep             # example in ESP-IDF to set variable angles in servo motor
-    │   ├── 3_rosserial_rviz          # example in ESP-IDF to interface with rviz environment as well as ESP32
-    │   ├── 4_rosserial_gazebo        # example in ESP-IDF to interface with gazebo environment as well as ESP32
-    │   ├── 5_servo_test_webserver    # example in ESP-IDF to set angles of servo over the webserver interface
-    │   └── components                # contains all the dependencies required for the above examples
-    │       ├── rosserial_esp32       # rosserial library to setup interface between ros environment and ESP32
-    │       └── sra-board-component   # library to interface with SRA board
+    ├── 1_chatter_listener                        # talker and listener script to understand the nodes and communications in ROS
+    ├── 2_simulation_dh                           # simulation of DH paramteres
+    ├── 3_simulation_rviz                         # simulation of MARIO bot on rviz
+    ├── 4_simulation_gazebo                       # simulation of MARIO bot on gazebo
+    ├── assets                                    # contains necessary gifs, images 
+    ├── firmware                                  # contains ESP-IDF examples for controlling servo motors and micro-ROS
+    │   ├── 1_servo_set_zero                      # example in ESP-IDF to set angles of all servo motor zero
+    │   ├── 2_servo_sweep                         # example in ESP-IDF to set variable angles in servo motor
+    │   ├── 3_microros_rviz                       # example in ESP-IDF to interface with rviz environment as well as ESP32
+    │   ├── 4_microros_gazebo                     # example in ESP-IDF to interface with gazebo environment as well as ESP32
+    │   ├── 5_servo_test_webserver                # example in ESP-IDF to set angles of servo over the webserver interface
+    │   └── components                            # contains all the dependencies required for the above examples
+    │       ├── micro_ros_espidf_component        # library to interface between micro-ROS environment and ESP32
+    │       └── sra-board-component               # library to interface with SRA board
     ├── LICENSE
     └── README.md 
 
@@ -50,17 +50,23 @@ This system, which is often referred as the message broker brings the two partie
 
 While ROS works on the same system, this system is also used in various other libraries like MQTT.
 
-## ESPIDF
+# MICRO-ROS
+micro-ROS is a robotic framework targeting embedded and deep-embedded robot components with extremely constrained computational resources. These devices have special characteristics: a minimum real-time operating system or no operating system, battery-powered, wireless low bandwidth connections, and intermittent operation with sleep periods.
+
+## ESP-IDF
 ESP-IDF is the development framework for Espressif SoCs.The [SRA Board](https://github.com/SRA-VJTI/sra-board-hardware-design) uses ESP32 as microcontroller, hence ESPIDF is required
 to code the ESP32. Examples included inside firmware directory has been written in ESPIDF version 4.2 .
 
-## ROSSERIAL
-ROS Serial is a point-to-point version of ROS communications over serial, primarily for integrating low-cost microcontrollers (Arduino) into ROS. 
-ROS serial consists of a general p2p protocol, libraries for use with Arduino, and nodes for the PC/Tablet side (currently in both Python and Java).
-
-## Installation of ROS
-
-ROS Noetic is now used by MARIO, and there are two ways to install it.
-Running `install_codes_jammy.sh` for 22.04 installs ROS Noetic via [Robostack](https://robostack.github.io/), whereas running `install_codes_focal.sh` for 20.04 installs ROS Noetic via the official ROS repository.
-
-`install_codes_jammy.sh` requires itself to be run twice, and run using the command `bash -i install_codes_jammy.sh`. The first time it is run, it will install the Robostack repository, and the second time it is run, it will install ROS Noetic and all the required packages.
+## Installation of ROS2
+- Clone SRA-VJTI's MARIO repository on your system
+```bash 
+git clone --recursive https://github.com/SRA-VJTI/MARIO.git
+```
+- Change terminal directory inside the cloned repository
+```bash
+cd MARIO/
+```
+- Run the installation script
+```bash 
+./installation.sh
+```

--- a/README.md
+++ b/README.md
@@ -1,57 +1,66 @@
-## Steps to run the demo in RViz 
-Introduction to RViz 2:
+# MARIO WORKSHOP 2.2
+*MARIO* abbreviation for *Manipulator on ROS Based Input Output* is a bot with 3 Degree of Freedom. It consists of two SG90 micro servo and one MG995 metal gear servo motor. The servo motors are placed on base, elbow and shoulder enabling it with 3 Degrees of Freedom.
 
-RViz 2 is a powerful 3D visualization tool provided by the Robot Operating System (ROS) 2 ecosystem. It serves as an essential component for roboticists, engineers, and researchers to visualize and interact with robot models, sensor data, and other important information in a simulated or real-world environment. RViz 2 offers a user-friendly interface with a wide range of features tailored to support the development, debugging, and testing of robotic systems.Here , along we can visualize the URDF of manipulator on Rviz using command line as well as GUI to give input.
-
-If you have not installed the joint_state_publishers and ros_control for ros-noetic, follow the commands given [here](https://github.com/SRA-VJTI/MARIO/tree/master/2_simulation_dh)
-
-* Remember : Whenever you are using ros commands in another terminal , make sure you  source the ros commands:
-```
-source install/setup.bash
-```
-  
-
-*  Run the launch file
-```
-  ros2 launch simulation_rviz display.launch.py 
-```
+## Sneek Peek 
 
 
-<p align="center">
-  <img src="../assets/launch1.png" width="500"/>
-</p>
+<p align="center"><img src="assets/bot2.png"></p>
+
+### Working of the Mario Bot
+
+<p align="center"><img src="assets/Gif2_AdobeExpress.gif" width="500" height="500"></p>
+
+### Mario bot simulated using Gazebo 
+
+<p align="center"><img src="assets/simulation.png"></p>
 
 
-   *  If you come across this error  
-Could not find the GUI, install the 'joint_state_publisher_gui' package  
-   *  Install  using  
-sudo apt install ros-<your_version_of_ros>-joint-state-publisher-gui
-   * Install all the packages required in the same way if needed.
- 
- ----------------------------------------------------------------------  
-  
-*  Once you are done with the visualisation with gui , Ctrl+ c to stop this .  
-  
-  
-*  For command line input    
 
-```
-roslaunch simulation_rviz mario_rviz.launch    
-```
-* To give input angles from command line , oepn new terminal and run 
-```
-ros2 run simulation_rviz rviz.py 
-```
+## File Structure 
+    ├── 1_chatter_listener            # talker and listener script to understand the nodes and communications in ROS
+    ├── 2_simulation_dh               # simulation of DH paramteres
+    ├── 3_simulation_rviz             # simulation of MARIO bot on rviz
+    ├── 4_simulation_gazebo           # simulation of MARIO bot on gazebo
+    ├── assets                        # contains necessary gifs, images 
+    ├── firmware                      # contains ESP-IDF examples for controlling servo motors and rosserial
+    │   ├── 1_servo_set_zero          # example in ESP-IDF to set angles of all servo motor zero
+    │   ├── 2_servo_sweep             # example in ESP-IDF to set variable angles in servo motor
+    │   ├── 3_rosserial_rviz          # example in ESP-IDF to interface with rviz environment as well as ESP32
+    │   ├── 4_rosserial_gazebo        # example in ESP-IDF to interface with gazebo environment as well as ESP32
+    │   ├── 5_servo_test_webserver    # example in ESP-IDF to set angles of servo over the webserver interface
+    │   └── components                # contains all the dependencies required for the above examples
+    │       ├── rosserial_esp32       # rosserial library to setup interface between ros environment and ESP32
+    │       └── sra-board-component   # library to interface with SRA board
+    ├── LICENSE
+    └── README.md 
 
-*you can use your this command to view the topics actively published . This will show if the values are published to the toppic we want to.
-```
-ros2 topic lsit
-```
-*To observe the published data in another terminal 
-```
-ros2 topic echo
-```
-Then initially set all values to zero , to get the default position of the manipulator .  
-After this you can now check for different values.
+## Kinematics
+* Mario workshop aims to provide the basic knowledge about the DH parameters, forward kinematics , inverse kinematics.
+  * DH Parameters :- Denavit–Hartenberg parameters (also called DH parameters) are the four parameters associated with a particular convention for attaching reference frames to the links of a spatial kinematic chain, or robot manipulator
+  * Forward Kinematics :- Forward kinematics refers to the use of the kinematic equations of a robot to compute the position of the end-effector from specified values for the joint parameters. The kinematics equations of the robot are used in robotics, computer games, and animation.
+  * Inverse Kinematics :- inverse kinematics is the mathematical process of calculating the variable joint parameters needed to place the end of a kinematic chain, such as a robot manipulator or animation character's skeleton, in a given position and orientation relative to the start of the chain.
+## ROS 
+ROS is an open-source, meta-operating system for your robot. It provides the services you would expect from an operating system, 
+including hardware abstraction, low-level device control, implementation of commonly-used functionality, message-passing between processes,
+and package management.
 
-As you give the input in the terminal , you can observe how the manipulator moved according to your input values of angles between links.
+## Publisher and Subscriber
+Publish/Subscribe is a messaging pattern that aims to decouple the sending (Publisher) and receiving (Subscriber) party. A real world example could be a sport mobile app that shows you up-to-date information of a particular football game you're interested in. In this case you are the subscriber, as you express interest in this specific game. On the other side sits the publisher, which is an online reporter that feeds a system with the actual match data.
+This system, which is often referred as the message broker brings the two parties together by sending the new data to all interested subscribers.
+
+While ROS works on the same system, this system is also used in various other libraries like MQTT.
+
+## ESPIDF
+ESP-IDF is the development framework for Espressif SoCs.The [SRA Board](https://github.com/SRA-VJTI/sra-board-hardware-design) uses ESP32 as microcontroller, hence ESPIDF is required
+to code the ESP32. Examples included inside firmware directory has been written in ESPIDF version 4.2 .
+
+## ROSSERIAL
+ROS Serial is a point-to-point version of ROS communications over serial, primarily for integrating low-cost microcontrollers (Arduino) into ROS. 
+ROS serial consists of a general p2p protocol, libraries for use with Arduino, and nodes for the PC/Tablet side (currently in both Python and Java).
+
+## Installation of ROS
+
+ROS Noetic is now used by MARIO, and there are two ways to install it.
+Running `install_codes_jammy.sh` for 22.04 installs ROS Noetic via [Robostack](https://robostack.github.io/), whereas running `install_codes_focal.sh` for 20.04 installs ROS Noetic via the official ROS repository.
+
+`install_codes_jammy.sh` requires itself to be run twice, and run using the command `bash -i install_codes_jammy.sh`. The first time it is run, it will install the Robostack repository, and the second time it is run, it will install ROS Noetic and all the required packages.

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ If you have not installed the joint_state_publishers and ros_control for ros-noe
 
 * Remember : Whenever you are using ros commands in another terminal , make sure you  source the ros commands:
 ```
-source install /setup.bash
+source install/setup.bash
 ```
   
 
 *  Run the launch file
 ```
-  roslaunch simulation_rviz display.launch 
+  ros2 launch simulation_rviz display.launch.py 
 ```
 
 
@@ -38,9 +38,9 @@ sudo apt install ros-<your_version_of_ros>-joint-state-publisher-gui
 ```
 roslaunch simulation_rviz mario_rviz.launch    
 ```
-* To give input angles from command line
+* To give input angles from command line , oepn new terminal and run 
 ```
-python3 3_simulation_rviz/scripts/rviz.py
+ros2 run simulation_rviz rviz.py 
 ```
 
 *you can use your this command to view the topics actively published . This will show if the values are published to the toppic we want to.
@@ -50,10 +50,6 @@ ros2 topic lsit
 *To observe the published data in another terminal 
 ```
 ros2 topic echo
-```
-*  Now ,On a different terminal, source ROS again and go to the simulation folder and write the following command
-```
-rosrun simulation_rviz pub_rviz.py  
 ```
 Then initially set all values to zero , to get the default position of the manipulator .  
 After this you can now check for different values.


### PR DESCRIPTION
- Added GUI to display_launch file and removed GUI from rviz_launch file .
- Removed unused publisher and node from rviz script file and updated it for rviz2 
- Added necessary requirements in the Cmakelists.txt 
- Updated the local README.md with few more commands and better description 
- Updated the main README.md as per MARIO v2.3 standards and techstack 